### PR TITLE
Fix original band fermi energy not not shifted to 0 

### DIFF
--- a/pyprocar/procarunfold/fatband.py
+++ b/pyprocar/procarunfold/fatband.py
@@ -20,6 +20,7 @@ def plot_band_weight(kslist,
                      color='blue',
                      axis=None,
                      width=10,
+                     fatness=4,
                      xticks=None,
                      cmap=mpl.cm.bwr,
                      weight_min=-0.1,
@@ -51,7 +52,7 @@ def plot_band_weight(kslist,
                 lwidths = np.array(wkslist[i]) * width
                 lc = LineCollection(
                     segments,
-                    linewidths=[4] * len(x),
+                    linewidths=[fatness] * len(x),
                     colors=[
                         colorConverter.to_rgba(
                             color, alpha=lwidth / (width + 0.001))

--- a/pyprocar/procarunfold/procar_unfolder.py
+++ b/pyprocar/procarunfold/procar_unfolder.py
@@ -66,10 +66,19 @@ class ProcarUnfolder(object):
              kname=['$\Gamma$', 'X', 'M', 'R', '$\Gamma$'],
              show_band=True,
              shift_efermi=True,
+             width=4.0,
+             color='blue',
              axis=None, 
+             savetab=None,
              ):
         xlist = [list(range(self.procar.kpointsCount))]
         uf = self.unfold()
+        if savetab is not None:
+            nk, nb=uf.shape
+            tab=np.zeros((nb, nk*2), dtype=float)
+            tab[:, ::2]=self.procar.bands.T
+            tab[:, 1::2]=uf.T
+            np.savetxt(savetab, tab, delimiter=',', fmt="%10.4f", header='# nkpoints: %s   nbands:%s \n#E(k1) w(k1) E(k2) w(k2) E(k3) w(k3)...'%(nk, nb))
         axes = plot_band_weight(
             xlist * self.procar.bandsCount,
             self.procar.bands.T,
@@ -77,11 +86,17 @@ class ProcarUnfolder(object):
             xticks=[kname, ktick],
             efermi=efermi,
             shift_efermi=shift_efermi,
+            fatness=width,
+            color=color,
             axis=axis)
         axes.set_ylim(ylim)
         axes.set_xlim(0, self.procar.kpointsCount - 1)
+        if shift_efermi:
+            shift=-efermi
+        else:
+            shift=0.0
         if show_band:
             for i in range(self.procar.bandsCount):
-                axes.plot(self.procar.bands[:,i], color='gray', linewidth=1, alpha=0.3)
+                axes.plot(self.procar.bands[:,i]+shift, color='gray', linewidth=1, alpha=0.3)
         return axes
 

--- a/pyprocar/scriptUnfold.py
+++ b/pyprocar/scriptUnfold.py
@@ -15,6 +15,9 @@ def unfold(
         knames=['$\Gamma$', 'K', 'M', '$\Gamma$', 'A', 'H', 'L', 'A'],
         print_kpts=False,
         show_band=True,
+        width=4,
+        color='blue',
+        savetab='unfold_result.csv',
         savefig='unfolded_band.png'):
     """
     Params:
@@ -29,6 +32,9 @@ def unfold(
     knames: see kticks
     print_kpts: print all the kpoints to screen. This is to help find the kticks and knames.
     show_band: whether to plot the bands before unfolding.
+    width: the width of the unfolded band. 
+    color: color of the unfoled band.
+    savetab: the csv file name of which  the table of unfolding result will be written into.
     savefig: the file name of which the figure will be saved.
     """
 
@@ -55,6 +61,9 @@ def unfold(
         ylim=elimit,
         ktick=kticks,
         kname=knames,
+        color=color,
+        width=width,
+        savetab=savetab,
         show_band=show_band)
     plt.savefig(savefig)
     plt.show()

--- a/sphinx/unfold.rst
+++ b/sphinx/unfold.rst
@@ -25,4 +25,7 @@ Then the unfold module can be used to plot the unfolded band as follows::
 	        knames=['$\Gamma$', 'K', 'M', '$\Gamma$', 'A', 'H', 'L', 'A'],
 	        print_kpts=False,
 	        show_band=True,
+                width=4,
+                color='blue',
+                savetab='unfolding.csv',
 	        savefig='unfolded_band.png')


### PR DESCRIPTION
Hi,
* I found a bug in the plotting of unfolded band. 
    When the band before unfolding is also plotted (with show_band option), the fermi energy is not 
    shifted. It does not affect the unfolded band. 
* Options to change the color and width of the unfolded band is also added. 
* Option to save the unfolding result to a csv file is added.
Best wishes,
HeXu