### PR TITLE
match "Reciprocal" in KPOINTS 

### DIFF
--- a/pyprocar/scriptBandsDosplot.py
+++ b/pyprocar/scriptBandsDosplot.py
@@ -177,7 +177,7 @@ def bandsdosplot(
             KPread = f.read()
             f.close()
 
-            KPmatrix = re.findall("reciprocal[\s\S]*", KPread)
+            KPmatrix = re.findall("reciprocal[\s\S]*", KPread, flags=re.IGNORECASE)
             tick_labels = np.array(re.findall("!\s(.*)", KPmatrix[0]))
             knames = []
             knames = [tick_labels[0]]

--- a/pyprocar/scriptBandsplot_old.py
+++ b/pyprocar/scriptBandsplot_old.py
@@ -157,7 +157,7 @@ def bandsplot_old(
         KPread = f.read()
         f.close()
 
-        KPmatrix = re.findall("reciprocal[\s\S]*", KPread)
+        KPmatrix = re.findall("reciprocal[\s\S]*", KPread, flags=re.IGNORECASE)
         tick_labels = np.array(re.findall("!\s(.*)", KPmatrix[0]))
         knames = []
         knames = [tick_labels[0]]


### PR DESCRIPTION
Errors happen when I use the KPOINTS files with "Reciprocal". Adding `flags=re.IGNORECASE` can support both "Reciprocal" and "reciprocal".