### PR TITLE
Update vasp.py

### DIFF
--- a/pyprocar/io/vasp.py
+++ b/pyprocar/io/vasp.py
@@ -52,10 +52,13 @@ class Outcar(collections.abc.Mapping):
         
         self.variables: dict = {}
         self.filename: Path = Path(filename)
-        self._get_axes_nk()
-
+        
         with open(self.filename, "r") as rf:
             self.file_str: str = rf.read()
+            
+        self._get_axes_nk()
+
+        
     def _get_axes_nk(self):
         """
         n_kx


### PR DESCRIPTION
Fix OUTCAR file parser to correctly get the number of points. `self._get_axes_nk()` should be called _after_ reading the OUTCAR file so `self.file_str` exists. This fixes 3D Fermi surface plotting.